### PR TITLE
feat(api): manage power state timeout

### DIFF
--- a/.mpsrc
+++ b/.mpsrc
@@ -59,5 +59,6 @@
   "consul_host": "localhost",
   "consul_port": "8500",
   "consul_key_prefix": "MPS",
-  "cira_last_seen": true
+  "cira_last_seen": true,
+  "timeout_ms_default": "10000"
 }

--- a/src/amt/APFProcessor.test.ts
+++ b/src/amt/APFProcessor.test.ts
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { Buffer } from 'node:buffer'
-import Common from '../utils/common.js'
-import { logger } from '../logging/index.js'
-import APFProcessor, { APFProtocol } from './APFProcessor.js'
-import { Environment } from '../utils/Environment.js'
-import { type CIRASocket } from '../models/models.js'
-import { type CIRAChannel } from './CIRAChannel.js'
-import { EventEmitter } from 'node:events'
 import { jest } from '@jest/globals'
 import { spyOn } from 'jest-mock'
+import { Buffer } from 'node:buffer'
+import { EventEmitter } from 'node:events'
+import { logger } from '../logging/index.js'
+import { type CIRASocket } from '../models/models.js'
+import Common from '../utils/common.js'
+import { Environment } from '../utils/Environment.js'
+import APFProcessor, { APFProtocol } from './APFProcessor.js'
+import { type CIRAChannel } from './CIRAChannel.js'
 
 describe('APFProcessor Tests', () => {
   afterEach(() => {
@@ -1060,7 +1060,8 @@ describe('APFProcessor Tests', () => {
         consul_host: 'localhost',
         consul_port: '8500',
         consul_key_prefix: 'MPS',
-        cira_last_seen: true
+        cira_last_seen: true,
+        timeout_ms_default: "10000"
       }
       Environment.Config = config
 

--- a/src/models/Config.d.ts
+++ b/src/models/Config.d.ts
@@ -48,6 +48,7 @@ export interface configType {
   consul_port: string
   consul_key_prefix: string
   cira_last_seen: boolean
+  timeout_ms_default: string
 }
 
 export interface certificatesType {

--- a/src/routes/amt/getPowerState.test.ts
+++ b/src/routes/amt/getPowerState.test.ts
@@ -10,6 +10,7 @@ import { HttpHandler } from '../../amt/HttpHandler.js'
 import { messages } from '../../logging/index.js'
 import { createSpyObj } from '../../test/helper/jest.js'
 import { serviceAvailableToElement } from '../../test/helper/wsmanResponses.js'
+import { TIMEOUT_MESSAGE, TimeoutError } from '../../utils/timeoutOpManagement.js'
 import { powerState } from './getPowerState.js'
 
 describe('power state', () => {
@@ -78,4 +79,25 @@ describe('power state', () => {
       errorDescription: messages.POWER_STATE_EXCEPTION
     })
   })
+  it('should get an error with status code 404, when get power state is timeout', async () => {
+    powerStateSpy.mockImplementation(() => {
+      throw new TimeoutError(TIMEOUT_MESSAGE)
+    })
+    await powerState(req, resSpy)
+    expect(resSpy.status).toHaveBeenCalledWith(404)
+    expect(resSpy.json).toHaveBeenCalledWith({
+      error: {
+         action: "Power action type does not exist",
+         alarm: "Alarm instance not found",
+         device: "Device not found/connected. Please connect again using CIRA.",
+         guid: "GUID does not exist in the payload",
+         invalidGuid: "GUID empty/invalid",
+         method: "Request does not contain method",
+         noMethod: "Requested method does not exists",
+         payload: "Request does not contain payload",
+       },
+      errorDescription: messages.POWER_STATE_EXCEPTION
+    })
+  })
+
 })

--- a/src/test/helper/config.ts
+++ b/src/test/helper/config.ts
@@ -70,5 +70,6 @@ export const config: configType = {
   consul_host: 'localhost',
   consul_port: '8500',
   consul_key_prefix: 'MPS',
-  cira_last_seen: true
+  cira_last_seen: true,
+  timeout_ms_default: "10000"
 }

--- a/src/utils/timeoutOpManagement.test.ts
+++ b/src/utils/timeoutOpManagement.test.ts
@@ -1,0 +1,38 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import * as tomgmt from './timeoutOpManagement.js'
+
+// getTimeoutMsDefault: Verifies the value in config file for default timeout. If not found, it returns a predefined value (10000 ms).
+
+describe('getTimeoutMsDefault', () => {
+    it('It must return a positive number is milliseconds (from config file or predefined)', () => {
+      const predefined = tomgmt.getTimeoutMsDefault()
+      expect(predefined).toBeGreaterThan(0)
+      expect(typeof predefined).toBe('number')})
+  })
+  
+describe('operationWithTimeout', () => {    
+    // Simulate an asynchronous operation that might take time
+
+    const myPromise = new Promise<string>(resolve => {
+        setTimeout(() => {
+            resolve("Operation completed");
+        }, 2000);
+    });
+
+    it('Operation finishes before the default timeout', () => {
+      const mytimeout = tomgmt.getTimeoutMsDefault()
+        
+      expect(tomgmt.operationWithTimeout(myPromise, mytimeout)).resolves.toBe("Operation completed");
+    })
+
+    it('Operation finishes after the default timeout', () => {
+    const mytimeout = 1000 // 1 second
+      
+    expect(tomgmt.operationWithTimeout(myPromise, mytimeout)).resolves.toBeInstanceOf(tomgmt.TimeoutError);
+    })
+
+})

--- a/src/utils/timeoutOpManagement.ts
+++ b/src/utils/timeoutOpManagement.ts
@@ -1,0 +1,49 @@
+import { Environment } from "./Environment.js";
+
+// Load default timeout from environment configuration
+
+export function getTimeoutMsDefault(): number {
+    if (Environment.Config?.timeout_ms_default) {
+        const timeoutMs = parseInt(Environment.Config.timeout_ms_default, 10);
+        if (!isNaN(timeoutMs) && timeoutMs > 0) {
+            return timeoutMs;
+        }            
+    }
+
+    return 10000; // Default value if the config is invalid
+}
+
+export const TIMEOUT_MS_DEFAULT = getTimeoutMsDefault(); // Default timeout in milliseconds    
+export const TIMEOUT_MESSAGE = 'Timeout' // Default message for timeout error
+
+// It extends the Error class to create a custom error type for timeout errors. This allows for more specific error handling and differentiation from other types of errors in the application.
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TimeoutError'
+    Object.setPrototypeOf(this, TimeoutError.prototype); // Recommended for proper instanceof checking
+  }
+}
+
+// It implements a timeout mechanism for promises (Any async method). It runs a race between the Promise<T> and the Timeout. The Promise<T> provides the result when the total processing time is lower than the defined Timeout. Otherwise, a timeout occurs, and it throws a TimeoutError instance.
+
+export async function operationWithTimeout<T>(promise: Promise<T>, timeoutMs: number = TIMEOUT_MS_DEFAULT, errorMessage:string = TIMEOUT_MESSAGE): Promise<T> {
+    if (typeof timeoutMs !== 'number' || timeoutMs <= 0) {
+        timeoutMs = TIMEOUT_MS_DEFAULT;
+    }
+
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      setTimeout(() => {
+          reject(new TimeoutError(errorMessage));
+      }, timeoutMs);
+    });
+
+
+  return Promise.race([promise, timeoutPromise])
+      .then(result => result)
+      .catch(error => {
+          throw error; 
+      });
+}
+


### PR DESCRIPTION
## PR Checklist

- [x ] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x ] All commented code has been removed
- [x ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

1. It incorporates helper functions and parameters to manage timeouts with async functions
2. It implements a timeout for getPowerState, defining 10000 milliseconds (or 10 seconds) as the default
3. A 404 HTTP response is given when a timeout is triggered. 

## Anything the reviewer should know when reviewing this PR?
1. Logs associated with the expected response: [test_getPowerState_ok_log.txt](https://github.com/user-attachments/files/19917550/test_getPowerState_ok_log.txt)
![test_getPowerState_ok](https://github.com/user-attachments/assets/bb8026d3-79ea-4151-9064-b2d2b4cb5b2f)

2. Logs associated with the timeout after unplugging the cord: [test_getPowerState_timeout_log.txt](https://github.com/user-attachments/files/19917554/test_getPowerState_timeout_log.txt)
![test_getPowerState_timeout](https://github.com/user-attachments/assets/7ae4f0cb-2860-4461-abc9-ba5d15480b77)

3. Logs associated with the expected response after plugging again the cord: [test_getPowerState_plugaftertimeout_log.txt](https://github.com/user-attachments/files/19917559/test_getPowerState_plugaftertimeout_log.txt)
![test_getPowerState_plugaftertimeout](https://github.com/user-attachments/assets/76b116bb-2ead-4795-a0dc-fff0804d28fd)

You can define a different value for the default timeout, modifying the "timeout_ms_default" parameter in .mpsrc.

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
None