### PR TITLE
ci(gh-actions): group vitest dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    # vitest and @vitest/* release in lockstep and declare exact peers on each
+    # other; one PR instead of a split that cannot install.
+    groups:
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds an npm `groups` entry so Dependabot raises `vitest` and `@vitest/*` as a single PR.

### Why

`@vitest/coverage-v8` declares an **exact** peer on the matching `vitest` version. When Dependabot bumps them separately, the resulting pair cannot install:

```
npm error code ERESOLVE
npm error While resolving: @vitest/coverage-v8@5.0.0
npm error Found: vitest@4.1.11
npm error   peer vitest@"5.0.0" from @vitest/coverage-v8@5.0.0
```

That is exactly what happened in #2652 — one PR bumping only the coverage package, failing all four build checks. #2654 fixes the current bump by hand; this change stops it recurring.

The `github-actions` ecosystem already uses this pattern for `codeql-action`, for the same lockstep reason.

### Note

Grouping only affects **future** Dependabot PRs; it does not retroactively combine existing ones.
