### PR TITLE
ci(gh-actions): drop node 20 and add node 24

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           persist-credentials: false
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - run: npm ci
       - run: npm run build-ext --if-present
       - run: rsync -a package.json README.md ./dist/

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -14,10 +14,10 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "imports": {
     "#src/*": "./dist/*"


### PR DESCRIPTION
Drops Node 20 and adds Node 24 to the test matrix.

### Why drop 20

The test matrix has run only `22.x` for some time, but `release.yml` and `semantic.yml` were still pinned to `20.x` — the only workflows left on it. Meanwhile **47 packages on `main` already declare `node >=22`** (`@augment-vir/*`, `@date-vir/*`, `got`, `@sindresorhus/is`, …), so `npm ci` on Node 20 emits a wall of `EBADENGINE` warnings today. They are warnings rather than errors only because there is no `.npmrc` setting `engine-strict`.

### Changes

| file | change |
|---|---|
| `package.json` | `engines.node`: `>=20` → `>=22` |
| `.github/workflows/release.yml` | `20.x` → `22.x` (+ step label) |
| `.github/workflows/semantic.yml` | `20.x` → `22.x` (+ step label) |
| `.github/workflows/node.js.yml` | matrix `[22.x]` → `[22.x, 24.x]` |

### Verification

Run locally on **Node v24.9.0**, against both current `main` (vitest 4) and the vitest 5 branch from #2654, so this is safe to merge in either order:

- `npm ci` — installs clean, **zero** `EBADENGINE` warnings
- `npm test` — 92 test files, 969 tests pass
- `npm run build` (tsc) — clean
